### PR TITLE
fix: Updating Unplayable Card Behavior

### DIFF
--- a/src/main/java/thePackmaster/actions/rippack/RipCardAction.java
+++ b/src/main/java/thePackmaster/actions/rippack/RipCardAction.java
@@ -40,6 +40,8 @@ public class RipCardAction extends AbstractGameAction {
             artCard.rawDescription = "";
             artCard.initializeDescription();
             artCard.target = artCard.cardID == ArtAttack.ID ? artCard.target : AbstractCard.CardTarget.NONE;
+            artCard.cost = rippedCard.cost;
+            artCard.costForTurn = rippedCard.costForTurn;
             AllCardsRippablePatches.AbstractCardFields.ripStatus.set(artCard, AllCardsRippablePatches.RipStatus.ART);
 
             //Set up Text Half properties

--- a/src/main/java/thePackmaster/patches/rippack/AllCardsRippablePatches.java
+++ b/src/main/java/thePackmaster/patches/rippack/AllCardsRippablePatches.java
@@ -209,7 +209,7 @@ public class AllCardsRippablePatches {
                     for (CtMethod m : methods) {
                         if (m.getName().equals("canUse")) {
                             m.insertBefore("{" +
-                                    "if(" + MakeTextCardsAlwaysPlayable.class.getName() + ".isTextCard($0)) { " +
+                                    "if(" + MakeTextCardsAlwaysPlayable.class.getName() + ".isArtCard($0)) { " +
                                     "return true;}}");
                         }
                     }
@@ -219,8 +219,8 @@ public class AllCardsRippablePatches {
             }
         }
 
-        public static boolean isTextCard(AbstractCard card) {
-            return Wiz.isTextCard(card);
+        public static boolean isArtCard(AbstractCard card) {
+            return Wiz.isArtCard(card);
         }
     }
 

--- a/src/main/java/thePackmaster/patches/rippack/AllCardsRippablePatches.java
+++ b/src/main/java/thePackmaster/patches/rippack/AllCardsRippablePatches.java
@@ -17,6 +17,7 @@ import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.utility.UseCardAction;
 import com.megacrit.cardcrawl.actions.utility.WaitAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.green.Reflex;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
@@ -35,8 +36,8 @@ import thePackmaster.cardmodifiers.rippack.TextCardModifier;
 import thePackmaster.cards.rippack.ArtAttack;
 import thePackmaster.util.Wiz;
 import thePackmaster.vfx.rippack.ShowCardAndRipEffect;
-import java.io.File;
 
+import java.io.File;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 
@@ -156,8 +157,8 @@ public class AllCardsRippablePatches {
         }
     }
 
-    @SpirePatch(clz = AbstractCard.class, method = "canUse")
-    public static class MakeAllTextCardsUsable {
+    @SpirePatch(clz = Reflex.class, method = "use")
+    public static class MakeReflexNotHaveAUse {
 
         @SpirePrefixPatch
         public static SpireReturn Prefix(AbstractCard __instance, AbstractPlayer p, AbstractMonster m) {
@@ -170,9 +171,63 @@ public class AllCardsRippablePatches {
     }
 
     //Dynamically patch triggerOnEndOfTurnForPlayingCard of cards
-    //This will make things like burn's effect not apply at the end of the players turn if it's an art car
+    //This will make things like burn's effect not apply at the end of the players turn if it's an art card
     @SpirePatch(clz = CardCrawlGame.class, method = SpirePatch.CONSTRUCTOR)
     public static class MakeArtCardsDoNothingAtEndOfTurnPatch {
+        public static void Raw(CtBehavior ctBehavior) throws NotFoundException {
+            ClassFinder finder = new ClassFinder();
+
+            finder.add(new File(Loader.STS_JAR));
+
+            for (ModInfo modInfo : Loader.MODINFOS) {
+                if (modInfo.jarURL != null) {
+                    try {
+                        finder.add(new File(modInfo.jarURL.toURI()));
+                    } catch (URISyntaxException e) {
+                        // do nothing
+                    }
+                }
+            }
+
+            // Get all classes for AbstractCard
+            ClassFilter filter = new AndClassFilter(
+                    new NotClassFilter(new InterfaceOnlyClassFilter()),
+                    new ClassModifiersClassFilter(Modifier.PUBLIC),
+                    new OrClassFilter(
+                            new org.clapper.util.classutil.SubclassClassFilter(AbstractCard.class),
+                            (classInfo, classFinder) -> classInfo.getClassName().equals(AbstractCard.class.getName())
+                    )
+            );
+
+            ArrayList<ClassInfo> foundClasses = new ArrayList<>();
+            finder.findClasses(foundClasses, filter);
+
+            for (ClassInfo classInfo : foundClasses) {
+                CtClass ctClass = ctBehavior.getDeclaringClass().getClassPool().get(classInfo.getClassName());
+
+                try {
+                    CtMethod[] methods = ctClass.getDeclaredMethods();
+                    for (CtMethod m : methods) {
+                        if (m.getName().equals("canUse")) {
+                            m.insertBefore("{" +
+                                    "if(" + MakeArtCardsDoNothingAtEndOfTurnPatch.class.getName() + ".isTextCard($0)) { " +
+                                    "return true;}}");
+                        }
+                    }
+                } catch (CannotCompileException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        public static boolean isTextCard(AbstractCard card) {
+            return Wiz.isTextCard(card);
+        }
+    }
+
+    //Dynamically patch canUse of cards to make Text halves always playable
+    @SpirePatch(clz = CardCrawlGame.class, method = SpirePatch.CONSTRUCTOR)
+    public static class MakeTextCardsAlwaysPlayable {
         public static void Raw(CtBehavior ctBehavior) throws NotFoundException {
             ClassFinder finder = new ClassFinder();
 

--- a/src/main/java/thePackmaster/patches/rippack/AllCardsRippablePatches.java
+++ b/src/main/java/thePackmaster/patches/rippack/AllCardsRippablePatches.java
@@ -17,6 +17,7 @@ import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.utility.UseCardAction;
 import com.megacrit.cardcrawl.actions.utility.WaitAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.curses.Normality;
 import com.megacrit.cardcrawl.cards.green.Reflex;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -163,6 +164,19 @@ public class AllCardsRippablePatches {
         @SpirePrefixPatch
         public static SpireReturn Prefix(AbstractCard __instance, AbstractPlayer p, AbstractMonster m) {
             if(isTextCard(__instance)) {
+                return SpireReturn.Return(true);
+            } else {
+                return SpireReturn.Continue();
+            }
+        }
+    }
+
+    @SpirePatch(clz = Normality.class, method = "canPlay")
+    public static class MakeArtNormalityDoNothing {
+
+        @SpirePrefixPatch
+        public static SpireReturn Prefix(Normality __instance, AbstractCard card) {
+            if(isArtCard(__instance)) {
                 return SpireReturn.Return(true);
             } else {
                 return SpireReturn.Continue();

--- a/src/main/java/thePackmaster/patches/rippack/AllCardsRippablePatches.java
+++ b/src/main/java/thePackmaster/patches/rippack/AllCardsRippablePatches.java
@@ -209,7 +209,7 @@ public class AllCardsRippablePatches {
                     for (CtMethod m : methods) {
                         if (m.getName().equals("canUse")) {
                             m.insertBefore("{" +
-                                    "if(" + MakeTextCardsAlwaysPlayable.class.getName() + ".isArtCard($0)) { " +
+                                    "if(" + MakeTextCardsAlwaysPlayable.class.getName() + ".isTextCard($0)) { " +
                                     "return true;}}");
                         }
                     }
@@ -219,8 +219,8 @@ public class AllCardsRippablePatches {
             }
         }
 
-        public static boolean isArtCard(AbstractCard card) {
-            return Wiz.isArtCard(card);
+        public static boolean isTextCard(AbstractCard card) {
+            return Wiz.isTextCard(card);
         }
     }
 

--- a/src/main/java/thePackmaster/patches/rippack/AllCardsRippablePatches.java
+++ b/src/main/java/thePackmaster/patches/rippack/AllCardsRippablePatches.java
@@ -170,61 +170,6 @@ public class AllCardsRippablePatches {
         }
     }
 
-    //Dynamically patch triggerOnEndOfTurnForPlayingCard of cards
-    //This will make things like burn's effect not apply at the end of the players turn if it's an art card
-    @SpirePatch(clz = CardCrawlGame.class, method = SpirePatch.CONSTRUCTOR)
-    public static class MakeArtCardsDoNothingAtEndOfTurnPatch {
-        public static void Raw(CtBehavior ctBehavior) throws NotFoundException {
-            ClassFinder finder = new ClassFinder();
-
-            finder.add(new File(Loader.STS_JAR));
-
-            for (ModInfo modInfo : Loader.MODINFOS) {
-                if (modInfo.jarURL != null) {
-                    try {
-                        finder.add(new File(modInfo.jarURL.toURI()));
-                    } catch (URISyntaxException e) {
-                        // do nothing
-                    }
-                }
-            }
-
-            // Get all classes for AbstractCard
-            ClassFilter filter = new AndClassFilter(
-                    new NotClassFilter(new InterfaceOnlyClassFilter()),
-                    new ClassModifiersClassFilter(Modifier.PUBLIC),
-                    new OrClassFilter(
-                            new org.clapper.util.classutil.SubclassClassFilter(AbstractCard.class),
-                            (classInfo, classFinder) -> classInfo.getClassName().equals(AbstractCard.class.getName())
-                    )
-            );
-
-            ArrayList<ClassInfo> foundClasses = new ArrayList<>();
-            finder.findClasses(foundClasses, filter);
-
-            for (ClassInfo classInfo : foundClasses) {
-                CtClass ctClass = ctBehavior.getDeclaringClass().getClassPool().get(classInfo.getClassName());
-
-                try {
-                    CtMethod[] methods = ctClass.getDeclaredMethods();
-                    for (CtMethod m : methods) {
-                        if (m.getName().equals("canUse")) {
-                            m.insertBefore("{" +
-                                    "if(" + MakeArtCardsDoNothingAtEndOfTurnPatch.class.getName() + ".isTextCard($0)) { " +
-                                    "return true;}}");
-                        }
-                    }
-                } catch (CannotCompileException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-
-        public static boolean isTextCard(AbstractCard card) {
-            return Wiz.isTextCard(card);
-        }
-    }
-
     //Dynamically patch canUse of cards to make Text halves always playable
     @SpirePatch(clz = CardCrawlGame.class, method = SpirePatch.CONSTRUCTOR)
     public static class MakeTextCardsAlwaysPlayable {
@@ -262,9 +207,70 @@ public class AllCardsRippablePatches {
                 try {
                     CtMethod[] methods = ctClass.getDeclaredMethods();
                     for (CtMethod m : methods) {
-                        if (m.getName().equals("triggerOnEndOfTurnForPlayingCard")) {
+                        if (m.getName().equals("canUse")) {
                             m.insertBefore("{" +
-                                    "if(" + MakeArtCardsDoNothingAtEndOfTurnPatch.class.getName() + ".isArtCard($0)) { " +
+                                    "if(" + MakeTextCardsAlwaysPlayable.class.getName() + ".isTextCard($0)) { " +
+                                    "return true;}}");
+                        }
+                    }
+                } catch (CannotCompileException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        public static boolean isTextCard(AbstractCard card) {
+            return Wiz.isTextCard(card);
+        }
+    }
+
+    //Dynamically patch a bunch of triggers of cards
+    //This will make things like burn's effect not apply at the end of the players turn if it's an art card
+    @SpirePatch(clz = CardCrawlGame.class, method = SpirePatch.CONSTRUCTOR)
+    public static class MakeArtCardsInertLikeDragonballs {
+        public static void Raw(CtBehavior ctBehavior) throws NotFoundException {
+            ClassFinder finder = new ClassFinder();
+
+            finder.add(new File(Loader.STS_JAR));
+
+            for (ModInfo modInfo : Loader.MODINFOS) {
+                if (modInfo.jarURL != null) {
+                    try {
+                        finder.add(new File(modInfo.jarURL.toURI()));
+                    } catch (URISyntaxException e) {
+                        // do nothing
+                    }
+                }
+            }
+
+            // Get all classes for AbstractCard
+            ClassFilter filter = new AndClassFilter(
+                    new NotClassFilter(new InterfaceOnlyClassFilter()),
+                    new ClassModifiersClassFilter(Modifier.PUBLIC),
+                    new OrClassFilter(
+                            new org.clapper.util.classutil.SubclassClassFilter(AbstractCard.class),
+                            (classInfo, classFinder) -> classInfo.getClassName().equals(AbstractCard.class.getName())
+                    )
+            );
+
+            ArrayList<ClassInfo> foundClasses = new ArrayList<>();
+            finder.findClasses(foundClasses, filter);
+
+            for (ClassInfo classInfo : foundClasses) {
+                CtClass ctClass = ctBehavior.getDeclaringClass().getClassPool().get(classInfo.getClassName());
+
+                try {
+                    CtMethod[] methods = ctClass.getDeclaredMethods();
+                    for (CtMethod m : methods) {
+                        if (m.getName().equals("triggerOnEndOfTurnForPlayingCard") ||
+                                m.getName().equals("triggerOnManualDiscard") ||
+                                m.getName().equals("triggerOnExhaust") ||
+                                m.getName().equals("triggerOnScry") ||
+                                m.getName().equals("triggerOnOtherCardPlayed") ||
+                                m.getName().equals("onRetained")) {
+
+                            m.insertBefore("{" +
+                                    "if(" + MakeArtCardsInertLikeDragonballs.class.getName() + ".isArtCard($0)) { " +
                                     "return;}}");
                         }
                     }


### PR DESCRIPTION
Unplayable cards now behave as follows:
Text half - always playable, any other effects on the card will work as if it was the normal card (ex. Normality limiting cards playable per turn to three)
Art half - Keeps the playability of the original card, but doesn't do anything else. So the art half of a Burn won't be playable, but also won't damage you at the end of the turn